### PR TITLE
Expose request body in errors.

### DIFF
--- a/lib/stream_service.rb
+++ b/lib/stream_service.rb
@@ -70,7 +70,7 @@ module StreamService
       request.body = body
       request.add_field "Content-Type", "text/json"
 
-      response = StreamService::StreamResponse.new(response: http.request(request))
+      response = StreamService::StreamResponse.new(response: http.request(request), body: body)
       response.raise_if_invalid!
     end
 

--- a/lib/stream_service/stream_response.rb
+++ b/lib/stream_service/stream_response.rb
@@ -6,10 +6,11 @@ class StreamService::StreamResponse
 
   attr_reader :response
 
-  def initialize(response: nil, items: nil, pagination_slug: nil)
+  def initialize(response: nil, items: nil, pagination_slug: nil, body: nil)
     @response = response
     @items = items
     @pagination_slug = pagination_slug
+    @body = body
   end
 
   def code
@@ -21,9 +22,9 @@ class StreamService::StreamResponse
     when Net::HTTPSuccess, Net::HTTPFound, Net::HTTPCreated
       self
     when Net::HTTPUnprocessableEntity
-      fail StreamService::HttpError, "Invalid Stream Server request (422): #{response.body}"
+      fail StreamService::HttpError, "Invalid Stream Server request (422). Request: #{@body}, Response: #{response.body}"
     when Net::HTTPBadRequest
-      fail StreamService::HttpError, "Stream Server encountered error (400): #{response.body}"
+      fail StreamService::HttpError, "Stream Server encountered error (400). Request: #{@body}, Response: #{response.body}"
     else
       fail StreamService::HttpError, "Error accessing Stream Server (#{response.code}): #{response.body}"
     end


### PR DESCRIPTION
This may help track down errors in production.

//cc @jayzes 