### PR TITLE
Reduce precision sent to roshi to match db.

### DIFF
--- a/lib/stream_service/item.rb
+++ b/lib/stream_service/item.rb
@@ -3,7 +3,7 @@ require 'active_support'
 require 'active_support/core_ext/hash'
 
 module StreamService
-  TIME_STAMP_FORMAT = '%Y-%m-%dT%H:%M:%S.%N%:z'
+  TIME_STAMP_FORMAT = '%Y-%m-%dT%H:%M:%S.%6N%:z'
 
   class Item
 

--- a/spec/stream_service_spec.rb
+++ b/spec/stream_service_spec.rb
@@ -6,13 +6,13 @@ describe StreamService do
   let(:item2) { StreamService::Item.from_post(post_id: 12345, user_id: "abc123", timestamp: DateTime.now, is_repost: false) }
   let!(:items) { [item1, item2] }
 
-  it 'can send stuff!' do
+  it 'can send items into a stream' do
     response = service.add_items(items)
 
     expect(response.code).to eq "201"
   end
 
-  it 'can get stuff!' do
+  it 'can get items back from a stream' do
     service.add_items(items)
     response = service.get_stream(stream_id: "abc123")
 
@@ -21,6 +21,18 @@ describe StreamService do
     expect(response.stream_items.first.stream_id).to eq "test:abc123"
     expect(response.stream_items.first.type).to eq 0
     expect(response.stream_items[1].type).to eq 1
+  end
+
+  it 'can remove items from a stream' do
+    service.add_items(items)
+    response = service.get_stream(stream_id: "abc123")
+
+    expect(response.stream_items.length).to eq 2
+
+    service.remove_items(items)
+    response = service.get_stream(stream_id: "abc123")
+
+    expect(response.stream_items.length).to eq 0
   end
 
   it 'can grab content from multiple users' do


### PR DESCRIPTION
This ensures that roshi only cares about microseconds and nanoseconds
are discarded. This is important because postgres only stores
microsecond precision. In cases where we write to the stream from an
object recently created in ruby memory we have nanosecond precision.

Due to the nature of roshi adding/removal of items from streams has a
"highest score wins" approach. In our case ts is our score.

This fix ensures that all writes to streams can be removed, as both
addition and removal will be the same timestamp.